### PR TITLE
fixed free trial redemption, and removed 20%off banner

### DIFF
--- a/src/app/panel-setup/metadata.ts
+++ b/src/app/panel-setup/metadata.ts
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Panel Setup | Espresso Hosting',
+  description: 'Setup your Minecraft hosting control panel account and get your login credentials.',
+  robots: {
+    index: false, // Don't index this page as it's a private user flow
+    follow: true,
+  },
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,7 +20,7 @@ const Header = () => {
 
   return (
     <header className="w-full bg-primary-200 text-white shadow-lg">
-      {/* Promotional Banner */}
+      {/* Promotional Banner
       <motion.div
         className="text-center py-2 text-sm bg-red-600 font-medium"
         initial={{ scale: 1 }}
@@ -28,7 +28,7 @@ const Header = () => {
         transition={{ duration: 1.5, repeat: Infinity, ease: "easeInOut" }}
       >
         <p>🎉 Limited Time Offer: Get 20% off on all plans! ( Applied automatically at checkout )  🎉</p>
-      </motion.div>
+      </motion.div> */}
 
       {/* Main Header */}
       <motion.nav

--- a/src/components/TrialClaim.tsx
+++ b/src/components/TrialClaim.tsx
@@ -34,8 +34,8 @@ export default function TrialClaim({ onSuccess, onError }: TrialClaimProps) {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          email: userEmail,
-          promo: 'trial100'
+          "email": userEmail,
+          "promo": 'trial100'
         }),
       });
 
@@ -54,8 +54,7 @@ export default function TrialClaim({ onSuccess, onError }: TrialClaimProps) {
     } finally {
       setIsProcessing(false);
     }
-  };
-  return (
+  };  return (
     <button
       type="button"
       onClick={(e) => {
@@ -64,8 +63,12 @@ export default function TrialClaim({ onSuccess, onError }: TrialClaimProps) {
         claimTrial();
       }}
       disabled={isProcessing || !isSignedIn}
-      style={{ pointerEvents: 'auto', cursor: isProcessing || !isSignedIn ? 'not-allowed' : 'pointer' }}
-      className={`w-full bg-gradient-to-r from-primary-600 to-accent-500 text-white font-bold py-3 px-6 rounded-lg transition-all duration-300 transform hover:scale-105 flex justify-center items-center z-[10001] ${
+      style={{ 
+        pointerEvents: 'auto', 
+        cursor: isProcessing || !isSignedIn ? 'not-allowed' : 'pointer',
+        position: 'relative'
+      }}
+      className={`w-full bg-gradient-to-r from-primary-600 to-accent-500 text-white font-bold py-3 px-6 rounded-lg transition-all duration-300 transform hover:scale-105 flex justify-center items-center z-[30000] ${
         isProcessing || !isSignedIn ? 'opacity-70' : ''
       }`}
     >

--- a/src/components/TrialModal.tsx
+++ b/src/components/TrialModal.tsx
@@ -35,7 +35,6 @@ export default function TrialModal({ isOpen, onClose, planName }: TrialModalProp
     setErrorMessage('');
     onClose();
   };
-
   const renderContent = () => {
     if (claimStatus === 'success') {
       return (
@@ -50,7 +49,8 @@ export default function TrialModal({ isOpen, onClose, planName }: TrialModalProp
           <div className="flex justify-center">
             <button
               onClick={handleClose}
-              className="bg-primary-600 hover:bg-primary-700 text-white font-bold py-2 px-6 rounded-lg"
+              className="bg-primary-600 hover:bg-primary-700 text-white font-bold py-2 px-6 rounded-lg z-[30001]"
+              style={{ position: 'relative', pointerEvents: 'auto' }}
             >
               Done
             </button>
@@ -70,7 +70,8 @@ export default function TrialModal({ isOpen, onClose, planName }: TrialModalProp
           <div className="flex justify-center">
             <button
               onClick={handleClose}
-              className="bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-6 rounded-lg"
+              className="bg-gray-600 hover:bg-gray-700 text-white font-bold py-2 px-6 rounded-lg z-[30001]"
+              style={{ position: 'relative', pointerEvents: 'auto' }}
             >
               Close
             </button>
@@ -84,13 +85,14 @@ export default function TrialModal({ isOpen, onClose, planName }: TrialModalProp
           <p className="text-gray-600 mb-6">
             You're about to claim a 1-month free trial of our {planName} hosting plan. This includes 2GB RAM, 4GB storage, and all features of our paid plans.
           </p>
-          <div className="mb-6">
+          <div className="mb-6 relative z-[30000]">
             <TrialClaim onSuccess={handleSuccess} onError={handleError} />
           </div>
           <div className="text-center">
             <button
               onClick={handleClose}
-              className="text-gray-600 hover:text-gray-800 font-medium"
+              className="text-gray-600 hover:text-gray-800 font-medium z-[30001]"
+              style={{ position: 'relative', pointerEvents: 'auto' }}
             >
               Cancel
             </button>
@@ -99,25 +101,38 @@ export default function TrialModal({ isOpen, onClose, planName }: TrialModalProp
       );
     }
   };
-
-  if (!mounted) return null;  return isOpen ? createPortal(
-    <div className="fixed inset-0 z-[9999] overflow-y-auto" style={{ pointerEvents: 'auto' }}>
+  if (!mounted) return null;  
+  
+  return isOpen ? createPortal(
+    <div className="fixed inset-0 z-[9999] overflow-y-auto">
       <div 
         className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center"
         onClick={handleClose} // Click anywhere outside the modal to close it
-        style={{ pointerEvents: 'auto' }}
       >
+        {/* Dark overlay */}
         <div className="fixed inset-0 transition-opacity" aria-hidden="true">
           <div className="absolute inset-0 bg-gray-500 opacity-75"></div>
         </div>
         
         <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
         
+        {/* Modal content */}
         <div 
-          className="relative inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full p-6 z-[10000]"
+          className="relative inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg w-[90%] p-6 z-[20000]"
           onClick={(e) => e.stopPropagation()} // Prevent clicks inside the modal from closing it
           style={{ pointerEvents: 'auto' }}
         >
+          {/* Close button */}
+          <button
+            onClick={handleClose}
+            className="absolute top-4 right-4 text-gray-500 hover:text-gray-700 focus:outline-none z-[20001]"
+            aria-label="Close modal"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12"></path>
+            </svg>
+          </button>
+          
           {renderContent()}
         </div>
       </div>


### PR DESCRIPTION
I've implemented the fixes to resolve the mobile issue with the trial modal. Here's what I changed:

Updated the Modal Structure:

Increased the z-index values significantly (from 9999-10001 to 20000-30001) to ensure the modal and its content appear above all other elements
Added a dedicated close button in the top-right corner for better mobile usability
Set the modal width to 90% on smaller screens with w-[90%] class
Improved the overall structure for better mobile responsiveness
Enhanced Button Interactivity:

Added [position: 'relative'](vscode-file://vscode-app/c:/Users/karti/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) to buttons to ensure they maintain their z-index context
Set explicit [pointerEvents: 'auto'](vscode-file://vscode-app/c:/Users/karti/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) on interactive elements to ensure they're clickable
Applied higher z-index values to all buttons (30000+) to make sure they're above the overlay
Fixed Modal Content:

Wrapped the TrialClaim component with a relative positioning context and higher z-index
Made sure all interactive elements in success and error states are properly accessible
Improved the positioning of elements to prevent them from being obscured